### PR TITLE
Serves api documentation on /api

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -27,7 +27,7 @@ The following environment variables are available:
 |    `POSTGRES_DB`     | The internal database used by the Postgres instance.                                                                                                 | liveinfo      | liveinfo                 |
 |   `POSTGRES_HOST`    | This is the host machine of the Postgres instance.                                                                                                   | localhost     | localhost                |
 | `POSTGRES_USERNAME`  | The username used to authenticate with the Postgres database. (required)                                                                             | none          | liveinfo                 |
-| `POSTGRES_PASSWORD`  | The passowrd used to authenticate with the Postgres database. (required)                                                                             | none          | SUPER_SECURE_PASSWORD123 |
+| `POSTGRES_PASSWORD`  | The password used to authenticate with the Postgres database. (required)                                                                             | none          | SUPER_SECURE_PASSWORD123 |
 |   `POSTGRES_PORT`    | The port used by the Postgres instance.                                                                                                              | 5432          | 5432                     |
 |  `POSTGRES_SSLMODE`  | Whether or not SSL should be used when connecting to the database. Available options [here](https://www.postgresql.org/docs/current/libpq-ssl.html). | disable       | prefer                   |
 |        `PORT`        | The port used by the server to listen for requests.                                                                                                  | 8080          | 3000                     |
@@ -39,3 +39,7 @@ The following environment variables are available:
 3. Start the databases using `docker-compose up -d`. This will start a PostgreSQL and a InfluxDB instance.
 4. Copy the `.env.example` file to `.env` and configure the environment variables. The default values are fine for local development.
 5. Run the backend using `go run .`. This will start the backend on port 8080.
+
+### API documentation
+
+If you want to see the API documentation, you can navigate to the `/api` path in your browser. This will show you a swagger documentation of the API.

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	_ "embed"
 	"encoding/json"
 	"log/slog"
 	"net/http"
@@ -27,6 +28,9 @@ func main() {
 
 	mux := http.NewServeMux()
 
+	apiDocs := http.StripPrefix("/api", http.FileServer(http.Dir("../docs")))
+	mux.Handle("GET /api/", apiDocs)
+
 	mux.HandleFunc("GET /api/current", currentHandler)
 	mux.HandleFunc("GET /api/current/{room}", currentRoomHandler)
 	mux.HandleFunc("POST /api/add-room", addRoomHandler)
@@ -34,7 +38,7 @@ func main() {
 
 	wrappedMux := logger.NewRequestLoggerMiddleware(mux)
 
-	slog.Info("Starting server with", "port", env.Port)
+	slog.Info("Starting server", "port", env.Port)
 	utils.LogFatal("Server crashed with error: ", http.ListenAndServe(":"+env.Port, wrappedMux))
 }
 

--- a/docs/api-contract.yml
+++ b/docs/api-contract.yml
@@ -4,6 +4,10 @@ info:
   version: '1.0'
   description: 'API to get the current (and past) availability of group rooms at Chalmers University of Technology.'
 
+servers:
+  - url: '/api'
+    description: 'The base path for all API requests.'
+
 paths:
   /current:
     get:

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,7 +19,7 @@
 		<script>
 			window.onload = () => {
 				window.ui = SwaggerUIBundle({
-					url: '/IMSX16_Kandidatarbete/api-contract.yml',
+					url: 'api-contract.yml',
 					dom_id: '#swagger-ui'
 				})
 			}


### PR DESCRIPTION
Due to ~me being lazy~ confusion, I made a tiny change to put the api documentation on `/api` when deployed. This is beneficial for a few reasons:
1. Enables the usage of the "try now" button in the Api Documentation.
2. Can always read the api, even if just developing locally.
3. Easier to find the api documentation location, instead of remembering/saving `https://albinens.github.io/IMSX16_Kandidatarbete/`